### PR TITLE
Quick fix to help inbetween fragments cache

### DIFF
--- a/src/fragmentHelper.ts
+++ b/src/fragmentHelper.ts
@@ -33,20 +33,33 @@ export async function handleTimestampPath(id: string, streamId: string, path: st
   // We will have to create a new timestamp bucket
   const relations: MongoFragment["relations"] = [];
 
+
+  // Let's see if there is a larger index this should not be the case, please ingest in order
+  const largerIndex: undefined | MongoFragment = (await mongo.find({ id, streamId, timeStamp: { "$gt": timestampValue } }).sort({ timeStamp: -1 }).limit(1).toArray())[0];
+
   // if there is a smallerIndex, relate to it
   if (smallerIndex) {
+    if (!!largerIndex) {
+      // This should not happen I think
+      // We found a bigger bucket, but we should not insert a inbetween bucket, because that bucket probably does not get a correct cache header
+      // This violates `maxSize` but we cannot fix the world, but this member is not present in current cached fragments :/
+      await mongo.updateOne({ streamId, id, timeStamp: largerIndex.timeStamp }, { $inc: { count: 1 }, $push: { members: memberId } });
+      return;
+    }
+
     relations.push({ type: RelationType.LessThan, value: timestampValue, bucket: smallerIndex.timeStamp!, path, timestampRelation: true });
     await mongo.updateOne({ streamId, id, timeStamp: smallerIndex.timeStamp },
       { "$push": { relations: { path, type: RelationType.GreaterThanOrEqualTo, value: timestampValue, bucket: timestampValue, timestampRelation: true } },
         "$set": { immutable: true } 
       })
+
   }
 
-  // There is no smaller index, let's see if there is a larger index 
-  const largerIndex: undefined | MongoFragment = (await mongo.find({ id, streamId, timeStamp: { "$gt": timestampValue } }).sort({ timeStamp: -1 }).limit(1).toArray())[0];
   if (!!largerIndex) {
     // This should not happen I think
-    // We potentially add a greater than or equal to relation to the next bucket
+    // We found a bigger bucket, but there exists no smaller bucket
+    // Let's just create a smaller bucket, how bad can it be?
+    // We add a greater than or equal to relation to the next bucket
     relations.push({ type: RelationType.GreaterThanOrEqualTo, value: largerIndex.timeStamp!, bucket: largerIndex.timeStamp!, path, timestampRelation: true });
     // And to that bucket, we add a less then relation to the new bucket
     await mongo.updateOne({ streamId, id, timeStamp: largerIndex.timeStamp }, { "$push": { relations: { path, type: RelationType.LessThan, value: largerIndex.timeStamp!, bucket: timestampValue, timestampRelation: true } } })


### PR DESCRIPTION
Problem:
When ingesting a member and the correct fragment is full, but it also found a bigger fragment, then a new fragment between the smaller and the bigger fragment.
This new fragment never gets full, so no immutable header is created.

This fix, pushed the member in the smaller fragment. This fragment is full but overflowing a fragment is better than no immutable cache header (I think).

New problem:
- This member is not added if the fragment is cached ...
- If no smaller fragment is found (so the member is smaller then everything that is ingested already), a smaller fragment is still created, which might not be cached correctly